### PR TITLE
Fix Linguist vendoring for assets/css and unblock local Bundler

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 assets/* linguist-vendored
 assets/talks/** linguist-vendored
 assets/cv/** linguist-vendored
+assets/css/** linguist-vendored

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,4 +280,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   2.0.2
+   2.5.22


### PR DESCRIPTION
## Summary
- **`.gitattributes`**: add `assets/css/** linguist-vendored`, same fix as the earlier `assets/talks`/`assets/cv` rules — without it, the self-hosted `w3.css` vendored in PR #19 would itself get counted as this repo's source code by GitHub's language detection.
- **`Gemfile.lock`**: bump the locked `BUNDLED WITH` from `2.0.2` to `2.5.22`. The old pin crashes on modern Ruby (3.2+) with a `String#untaint` `NoMethodError` (that method was removed from Ruby; Bundler 2.0.2 predates the removal). Doesn't affect the live GitHub Pages build (their build servers run their own curated toolchain), but it breaks `bundle install`/`bundle exec jekyll serve` for anyone running this repo locally on a current Ruby. Only the `BUNDLED WITH` line changed — no gem versions or the locked platform were touched, verified with `bundle check`.

## Test plan
- [ ] Confirm GitHub Pages build succeeds
- [ ] After merge, confirm `assets/css` no longer counts toward the repo's language breakdown once GitHub recomputes it
- [ ] Optional: confirm `bundle install` succeeds locally on a modern Ruby without the previous crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUtuP5XfRZxvX6VUkCo484

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUtuP5XfRZxvX6VUkCo484)_